### PR TITLE
SMT Sampler Implementation

### DIFF
--- a/src/main/scala/maltese/smt/SMTExprEval.scala
+++ b/src/main/scala/maltese/smt/SMTExprEval.scala
@@ -4,7 +4,72 @@
 
 package maltese.smt
 
+trait SMTEvalCtx {
+  def getBVSymbol(name: String): BigInt
+  def getArraySymbol(name: String): ArrayValue
+  def startVariableScope(name: String, value: BigInt): Unit
+  def endVariableScope(name: String): Unit
+  def constArray(indexWidth: Int, value: BigInt): ArrayValue
+}
+
+trait ArrayValue {
+  def ==(other: ArrayValue): Boolean
+  def read(index: BigInt): BigInt
+  def write(index: Option[BigInt], value: BigInt): ArrayValue
+}
+
 object SMTExprEval {
+
+  def eval(expr: BVExpr)(implicit ctx: SMTEvalCtx): BigInt = {
+    val value = expr match {
+      case BVLiteral(value, _) => value
+      case BVSymbol(name, _) => ctx.getBVSymbol(name)
+      case BVExtend(e, by, signed) => doBVExtend(eval(e), e.width, by, signed)
+      case BVSlice(e, hi, lo) => doBVSlice(eval(e), hi, lo)
+      case BVNot(e) => doBVNot(eval(e), e.width)
+      case BVNegate(e) => doBVNegate(eval(e), e.width)
+      case BVImplies(a, b) => doBVNot(eval(a), 1) | eval(b)
+      case BVEqual(a, b) => doBVEqual(eval(a), eval(b))
+      case BVComparison(op, a, b, signed) => doBVCompare(op, eval(a), eval(b), a.width, signed)
+      case BVOp(op, a, b) => doBVOp(op, eval(a), eval(b), a.width)
+      case BVConcat(a, b) => doBVConcat(eval(a), eval(b), bWidth = b.width)
+      case ArrayRead(array, index) => evalArray(array).read(eval(index))
+      case BVIte(cond, tru, fals) =>
+        val c = eval(cond)
+        assert(c == 0 || c == 1)
+        if(c == 1) { eval(tru) } else { eval(fals) }
+      case BVSelect(_) => throw new NotImplementedError("BVSelect")
+      case ArrayEqual(a, b) => if(evalArray(a) == evalArray(b)) BigInt(1) else BigInt(0)
+      case BVForall(variable, e) =>
+        val maxValue = (BigInt(1) << variable.width) - 1
+        if(maxValue > 4096) {
+          throw new NotImplementedError(s"TODO: deal with forall of large ranges in witness simulator: $variable has ${variable.width} bits!")
+        }
+        val res = (0 to maxValue.toInt).iterator.forall { value =>
+          ctx.startVariableScope(variable.name, value)
+          // evaluate expression
+          val isTrue = eval(e) == 1
+          ctx.endVariableScope(variable.name)
+          isTrue
+        }
+        if(res) BigInt(1) else BigInt(0)
+      case _ : BVFunctionCall => throw new NotImplementedError("function call")
+    }
+    value
+  }
+
+  def evalArray(expr: ArrayExpr)(implicit ctx: SMTEvalCtx): ArrayValue = expr match {
+    case s : ArraySymbol => ctx.getArraySymbol(s.name)
+    case ArrayConstant(e, indexWidth) =>
+      ctx.constArray(indexWidth, eval(e))
+    case ArrayStore(array, index, data) =>
+      evalArray(array).write(Some(eval(index)), eval(data))
+    case ArrayIte(cond, tru, fals) =>
+      val c = eval(cond)
+      assert(c == 0 || c == 1)
+      if(c == 1) { evalArray(tru) } else { evalArray(fals) }
+    case other => throw new RuntimeException(s"Unsupported array expression $other")
+  }
 
   def doBVExtend(e: BigInt, width: Int, by: Int, signed: Boolean): BigInt = {
     if(signed && isNegative(e, width)) {
@@ -63,4 +128,21 @@ object SMTExprEval {
   private def isNegative(value: BigInt, w: Int) = !isPositive(value, w)
   private def flipBits(value: BigInt, w: Int) = ~value & mask(w)
   private def bool(b: Boolean): BigInt = if(b) BigInt(1) else BigInt(0)
+}
+
+case class LocalEvalCtx(bv: Map[String, BigInt], array: Map[String, ArrayValue] = Map()) extends SMTEvalCtx {
+  override def getBVSymbol(name: String): BigInt = bv.getOrElse(name, {
+    variables.find(_._1 == name).map(_._2).getOrElse(throw new RuntimeException(s"Unknown symbol $name!"))
+  })
+  override def getArraySymbol(name: String) = array(name)
+
+  private val variables = scala.collection.mutable.ArrayStack[(String, BigInt)]()
+  override def startVariableScope(name: String, value: BigInt): Unit = {
+    variables.push((name, value))
+  }
+  override def endVariableScope(name: String): Unit = {
+    val old = variables.pop()
+    assert(old._1 == name)
+  }
+  override def constArray(indexWidth: Int, value: BigInt) = ???
 }

--- a/src/main/scala/maltese/smt/solvers/SMTLibSolver.scala
+++ b/src/main/scala/maltese/smt/solvers/SMTLibSolver.scala
@@ -43,7 +43,7 @@ class Z3SMTLib extends SMTLibSolver(List("z3", "-in")) {
 
 /** provides basic facilities to interact with any SMT solver that supports a SMTLib base textual interface */
 abstract class SMTLibSolver(cmd: List[String]) extends Solver {
-  protected val debug: Boolean = true
+  protected val debug: Boolean = false
 
   override def push(): Unit = {
     writeCommand("(push 1)")

--- a/src/main/scala/maltese/smt/solvers/SMTLibSolver.scala
+++ b/src/main/scala/maltese/smt/solvers/SMTLibSolver.scala
@@ -33,12 +33,17 @@ class Z3SMTLib extends SMTLibSolver(List("z3", "-in")) {
     case None => writeCommand("(set-logic ALL)")
     case Some(_) => // ignore
   }
+
+  def softAssert(expr: smt.BVExpr, weight: Int = 1): Unit = {
+    // TODO: println("TODO: declare free variables automatically")
+    writeCommand(s"(assert-soft ${serialize(expr)} :weight $weight)")
+  }
 }
 
 
 /** provides basic facilities to interact with any SMT solver that supports a SMTLib base textual interface */
 abstract class SMTLibSolver(cmd: List[String]) extends Solver {
-  protected val debug: Boolean = false
+  protected val debug: Boolean = true
 
   override def push(): Unit = {
     writeCommand("(push 1)")
@@ -100,7 +105,7 @@ abstract class SMTLibSolver(cmd: List[String]) extends Solver {
     }
   }
 
-  private def serialize(e: smt.SMTExpr): String = smt.SMTLibSerializer.serialize(e)
+  protected def serialize(e: smt.SMTExpr): String = smt.SMTLibSerializer.serialize(e)
   private def serialize(c: SMTCommand): String = smt.SMTLibSerializer.serialize(c)
 
   private val proc = new InteractiveProcess(cmd, true)

--- a/src/main/scala/maltese/smt/solvers/SMTLibSolver.scala
+++ b/src/main/scala/maltese/smt/solvers/SMTLibSolver.scala
@@ -38,6 +38,11 @@ class Z3SMTLib extends SMTLibSolver(List("z3", "-in")) {
     // TODO: println("TODO: declare free variables automatically")
     writeCommand(s"(assert-soft ${serialize(expr)} :weight $weight)")
   }
+
+  def setTimeout(seconds: Int): Unit = {
+    require(seconds > 0)
+    writeCommand(s"(set-option :timeout $seconds)")
+  }
 }
 
 

--- a/src/main/scala/verif/SMTSampler.scala
+++ b/src/main/scala/verif/SMTSampler.scala
@@ -1,0 +1,98 @@
+// Copyright 2020 The Regents of the University of California
+// Copyright 2018 The Regents of the University of California
+// released under BSD 3-Clause License
+// author: Kevin Laeufer <laeufer@cs.berkeley.edu>
+// based on the original implementation by Rafael Dutra <rtd@cs.berkeley.edu>
+
+
+package verif
+
+import maltese.smt
+import maltese.smt.solvers.IsSat
+
+/** Implements the smt sampler algorithm using Z3
+ *
+ *  Reference:
+ *  Rafael Dutra and Kevin Laeufer and Jonathan Bachrach and Koushik Sen,
+ *  "Efficient Sampling of SAT Solutions for Testing,"
+ *  in 40th International Conference on Software Engineering (ICSE'18), IEEE, 2018 .
+ *
+ * */
+class SMTSampler private(solver: smt.solvers.Z3SMTLib, support: Seq[smt.BVSymbol], seed: Long) {
+  val width = support.map(_.width).sum
+  private val supportBits = support.flatMap(toBits).reverse.zipWithIndex
+  assert(supportBits.length == width)
+  private val random = new scala.util.Random(seed)
+
+
+  def run(): Iterable[Seq[(String, BigInt)]] = {
+    // start at a random solution
+    val start = BigInt(width, random)
+
+    // find closest solution
+    val closest = findClosestSolution(start)
+
+    List(modelToAssignments(closest))
+  }
+
+  private def modelToAssignments(model: BigInt): Seq[(String, BigInt)] = {
+    var res = model
+    support.reverse.map { sym =>
+      val mask = (BigInt(1) << sym.width) - 1
+      val value = res & mask
+      res = res >> sym.width
+      sym.name -> value
+    }.reverse
+  }
+
+  private def findClosestSolution(start: BigInt): BigInt = {
+    solver.push()
+    assignSoft(start)
+    val r = solver.check()
+    assert(r.isSat)
+    val model = readModel()
+    solver.pop()
+    model
+  }
+
+  private def readModel(): BigInt = {
+    var res = BigInt(0)
+    var resNext = BigInt(0)
+    support.reverse.foreach { sym =>
+      val value = solver.getValue(sym).get
+      res = (resNext | value)
+      resNext = (res << sym.width)
+    }
+    res
+  }
+
+  private def assignSoft(bits: BigInt): Unit = {
+    supportBits.foreach { case (expr, ii) =>
+      val value = (bits >> ii) & 1
+      val constraint = smt.BVEqual(expr, smt.BVLiteral(value, 1))
+      solver.softAssert(constraint)
+    }
+  }
+
+  private def toBits(sym: smt.BVSymbol): List[smt.BVExpr] = {
+    if(sym.width == 1) { List(sym) } else {
+      (0 until sym.width).map(i => smt.BVSlice(sym, i, i)).toList
+    }
+  }
+}
+
+object SMTSampler {
+  def apply(support: Seq[smt.BVSymbol], constraints: Seq[smt.BVExpr], seed: Long = 0): Option[SMTSampler] = {
+    val solver = new smt.solvers.Z3SMTLib()
+    solver.setLogic(smt.solvers.QF_BV)
+    // declare all variables in the support
+    support.foreach(s => solver.runCommand(smt.solvers.DeclareFunction(s, Seq())))
+    // add all hard constraints
+    constraints.foreach(c => solver.assert(c))
+    // sanity check to see if the formula is actually satisfiable (if not, there is no use in trying to sample it)
+    solver.check() match {
+      case IsSat => Some(new SMTSampler(solver, support, seed))
+      case _ => None
+    }
+  }
+}

--- a/src/main/scala/verif/SMTSampler.scala
+++ b/src/main/scala/verif/SMTSampler.scala
@@ -11,6 +11,8 @@ import maltese.smt
 import maltese.smt.solvers.IsSat
 import scala.collection.mutable
 
+case class SMTSamplerOptions(alphaMin: Double, maxCombine: Int, maxSamples: Int)
+
 /** Implements the smt sampler algorithm using Z3
  *
  *  Reference:
@@ -19,26 +21,57 @@ import scala.collection.mutable
  *  in 40th International Conference on Software Engineering (ICSE'18), IEEE, 2018 .
  *
  * */
-class SMTSampler private(solver: smt.solvers.Z3SMTLib, support: List[smt.BVSymbol], constraints: List[smt.BVExpr], seed: Long) {
+class SMTSampler private(
+  solver: smt.solvers.Z3SMTLib, opt: SMTSamplerOptions,
+  support: List[smt.BVSymbol], constraints: List[smt.BVExpr],
+  random: scala.util.Random) {
+  private type Model = List[BigInt]
   private val supportBits = support.map(toBits)
-  private val random = new scala.util.Random(seed)
   assert(support.nonEmpty, "Cannot work with empty support!")
 
   def run(): Iterable[Seq[(String, BigInt)]] = {
     // start at a random solution
     val start = getRandomAssignment
+    val res = epoch(start, opt.maxSamples)
 
-    // find closest solution
-    val closest = findClosestSolution(start)
-    assert(isValid(closest))
+    // exit solver
+    solver.close()
 
-    // find neighbors
-    val neighbors = computeAllNeighboringSolutions(closest)
-
-    neighbors.map(modelToAssignments)
+    res.take(opt.maxSamples).map(modelToAssignments)
   }
 
-  private def findClosestSolution(start: List[BigInt]): List[BigInt] = {
+  private def epoch(randomAssignment: Model, maxSamples: Int): List[Model] = {
+    // find closest solution
+    val start = findClosestSolution(randomAssignment)
+    assert(isValid(start))
+
+    // to avoid duplicates
+    val seen = mutable.HashSet[BigInt]()
+    seen.add(modelToBigInt(start))
+
+    // find neighbors
+    val neighbors = computeAllNeighboringSolutions(start, seen)
+
+    // check if we already have enough
+    if(neighbors.size + 1 >= maxSamples) {
+     start +: neighbors
+    } else {
+      val (_, _, solutions) =
+        (0 to opt.maxCombine).foldLeft((1.0, neighbors, neighbors)) {
+          case ((prevAlpha, last, all), k) =>
+            if (prevAlpha < opt.alphaMin || all.size + 1 >= maxSamples) {
+              (0.0, last, all)
+            } else {
+              val remaining = maxSamples - all.size - 1
+              val (newSolutions, newAlpha) = combine(start, last, neighbors, seen, remaining)
+              (newAlpha, newSolutions, all ++ newSolutions)
+            }
+        }
+      start +: solutions
+    }
+  }
+
+  private def findClosestSolution(start: Model): Model = {
     solver.push()
     assignSoft(start)
     val r = solver.check()
@@ -48,17 +81,13 @@ class SMTSampler private(solver: smt.solvers.Z3SMTLib, support: List[smt.BVSymbo
     model
   }
 
-  private def computeAllNeighboringSolutions(start: List[BigInt]): List[List[BigInt]] = {
-    // to avoid duplicates
-    val seen = mutable.HashSet[BigInt]()
-    seen.add(modelToBigInt(start))
-
+  private def computeAllNeighboringSolutions(start: Model, seen: mutable.HashSet[BigInt]): List[Model] = {
     // soft constrain start solution
     solver.push()
     assignSoft(start)
 
     // all bits that we can flip
-    var results = List[List[BigInt]]()
+    var results = List[Model]()
     supportBits.zip(start).foreach { case (bits, value) =>
       bits.foreach { case (expr, ii) =>
         val bitValue = (value >> ii) & 1
@@ -88,15 +117,54 @@ class SMTSampler private(solver: smt.solvers.Z3SMTLib, support: List[smt.BVSymbo
     results
   }
 
-  private def modelToAssignments(model: List[BigInt]): List[(String, BigInt)] =
+  private def combine(start: Model, last: List[Model], neighbors: List[Model], seen: mutable.HashSet[BigInt], maxSamples: Int):
+  (List[Model], Double) = {
+    var newCount = 0
+    var validCount = 0
+    val solutions = neighbors.flatMap { a =>
+      last.flatMap { b =>
+        if (validCount < maxSamples) {
+          // combine mutations relative to the starting solution
+          val n = phi(start, a, b)
+
+          // check if we have already seen this solution
+          val i = modelToBigInt(n)
+          if (!seen(i)) {
+            seen.add(i)
+            newCount += 1
+
+            // check to see if the solution is actually a valid solution
+            if (isValid(n)) {
+              validCount += 1
+              Some(n)
+            } else { None }
+          } else { None }
+        } else { None }
+      }
+    }
+    val alpha = validCount.toDouble / newCount.toDouble
+    (solutions, alpha)
+  }
+
+  // the combination function
+  private def phi(start: Model, aModel: Model, bModel: Model): Model = {
+    start.zip(aModel).zip(bModel).map { case ((s, a), b) =>
+      val mutA = a ^ s
+      val mutB = b ^ s
+      val combMut = mutA | mutB
+      s ^ combMut
+    }
+  }
+
+  private def modelToAssignments(model: Model): List[(String, BigInt)] =
     model.zip(support).map{ case (value, sym) => sym.name -> value }
 
-  private def getRandomAssignment: List[BigInt] = support.map(sym => BigInt(sym.width, random))
+  private def getRandomAssignment: Model = support.map(sym => BigInt(sym.width, random))
 
-  private def readModel(): List[BigInt] = support.map { solver.getValue(_).get }
+  private def readModel(): Model = support.map { solver.getValue(_).get }
 
   // this models the SMTbit approach where every bit is individually constrained
-  private def assignSoft(values: List[BigInt]): Unit = {
+  private def assignSoft(values: Model): Unit = {
     supportBits.zip(values).foreach { case (bits, value) =>
       bits.foreach { case (expr, ii) =>
         val bitValue = (value >> ii) & 1
@@ -113,7 +181,7 @@ class SMTSampler private(solver: smt.solvers.Z3SMTLib, support: List[smt.BVSymbo
   }
 
   // check whether the plugging the model into the formula will result in a true result
-  private def isValid(model: List[BigInt]): Boolean = {
+  private def isValid(model: Model): Boolean = {
     val mapping = support.zip(model).map(t => t._1.name -> t._2).toMap
     val ctx = smt.LocalEvalCtx(mapping)
     val res = constraints.map(c => smt.SMTExprEval.eval(c)(ctx))
@@ -122,7 +190,7 @@ class SMTSampler private(solver: smt.solvers.Z3SMTLib, support: List[smt.BVSymbo
 
   private val shifts = support.map(_.width).dropRight(1)
   private val singleVar = support.size == 1
-  private def modelToBigInt(model: List[BigInt]): BigInt = {
+  private def modelToBigInt(model: Model): BigInt = {
     if(singleVar) { model.head } else {
       model.tail.zip(shifts).foldLeft(model.head) { case (prev, (value, shift)) =>
         (prev << shift) | value
@@ -132,7 +200,8 @@ class SMTSampler private(solver: smt.solvers.Z3SMTLib, support: List[smt.BVSymbo
 }
 
 object SMTSampler {
-  def apply(support: List[smt.BVSymbol], constraints: List[smt.BVExpr], seed: Long = 0): Option[SMTSampler] = {
+  val Default = SMTSamplerOptions(alphaMin = 0.5, maxCombine = 4, maxSamples = 100)
+  def apply(support: List[smt.BVSymbol], constraints: List[smt.BVExpr], opt: SMTSamplerOptions = Default, seed: Long = 0): Option[SMTSampler] = {
     val solver = new smt.solvers.Z3SMTLib()
     solver.setLogic(smt.solvers.QF_BV)
     // declare all variables in the support
@@ -141,7 +210,9 @@ object SMTSampler {
     constraints.foreach(c => solver.assert(c))
     // sanity check to see if the formula is actually satisfiable (if not, there is no use in trying to sample it)
     solver.check() match {
-      case IsSat => Some(new SMTSampler(solver, support, constraints, seed))
+      case IsSat =>
+        val random = new scala.util.Random(seed)
+        Some(new SMTSampler(solver, opt, support, constraints, random))
       case _ => None
     }
   }

--- a/src/test/scala/verif/SMTSamplerTest.scala
+++ b/src/test/scala/verif/SMTSamplerTest.scala
@@ -1,0 +1,26 @@
+// Copyright 2020 The Regents of the University of California
+// released under BSD 3-Clause License
+// author: Kevin Laeufer <laeufer@cs.berkeley.edu>
+
+package verif
+
+import maltese.smt
+import org.scalatest.FlatSpec
+
+class SMTSamplerTest extends FlatSpec {
+  behavior of "SMTSampler"
+
+
+  it should "return a valid sample" in {
+    val (a, b) = (smt.BVSymbol("a", 8), smt.BVSymbol("b", 8))
+    val c0 = smt.BVComparison(smt.Compare.Greater, smt.BVLiteral(3, 8), a, signed = false)
+    val c1 = smt.BVComparison(smt.Compare.Greater, b, smt.BVLiteral(3, 8), signed = false)
+
+    val sampler = SMTSampler(List(a, b), List(c0, c1)).get
+    val sample = sampler.run().head.toMap
+    assert(sample.contains("a"))
+    assert(sample("a") < 3)
+    assert(sample.contains("b"))
+    assert(sample("b") > 3)
+  }
+}

--- a/src/test/scala/verif/SMTSamplerTest.scala
+++ b/src/test/scala/verif/SMTSamplerTest.scala
@@ -11,16 +11,18 @@ class SMTSamplerTest extends FlatSpec {
   behavior of "SMTSampler"
 
 
-  it should "return a valid sample" in {
+  it should "return a valid samples" in {
     val (a, b) = (smt.BVSymbol("a", 8), smt.BVSymbol("b", 8))
     val c0 = smt.BVComparison(smt.Compare.Greater, smt.BVLiteral(3, 8), a, signed = false)
     val c1 = smt.BVComparison(smt.Compare.Greater, b, smt.BVLiteral(3, 8), signed = false)
 
     val sampler = SMTSampler(List(a, b), List(c0, c1)).get
-    val sample = sampler.run().head.toMap
-    assert(sample.contains("a"))
-    assert(sample("a") < 3)
-    assert(sample.contains("b"))
-    assert(sample("b") > 3)
+    val samples = sampler.run()
+    samples.map(_.toMap).foreach { sample =>
+      assert(sample.contains("a"))
+      assert(sample("a") < 3)
+      assert(sample.contains("b"))
+      assert(sample("b") > 3)
+    }
   }
 }

--- a/src/test/scala/verif/SMTSamplerTest.scala
+++ b/src/test/scala/verif/SMTSamplerTest.scala
@@ -16,8 +16,10 @@ class SMTSamplerTest extends FlatSpec {
     val c0 = smt.BVComparison(smt.Compare.Greater, smt.BVLiteral(3, 8), a, signed = false)
     val c1 = smt.BVComparison(smt.Compare.Greater, b, smt.BVLiteral(3, 8), signed = false)
 
-    val sampler = SMTSampler(List(a, b), List(c0, c1)).get
+    val opt = SMTSamplerOptions(alphaMin = 0.5, maxCombine = 5, maxSamples = 40)
+    val sampler = SMTSampler(List(a, b), List(c0, c1), opt, seed = 100).get
     val samples = sampler.run()
+    assert(samples.size == opt.maxSamples)
     samples.map(_.toMap).foreach { sample =>
       assert(sample.contains("a"))
       assert(sample("a") < 3)


### PR DESCRIPTION
This should be ready to merge @vighneshiyer .

Some more things that could be implemented later, but are not required for a prototype:
- use timeouts to stop the solver if it is taking too long
- maybe do random bitflips for large inputs sizes instead of trying to find all the neighbors
- switch to a more lazy interface where samples are generated on demand

Before I change the interface to be lazy, it would be nice to have a better idea on how the frontend is going to deal with multiple samples.